### PR TITLE
Fix dashboard launch and remove finance button

### DIFF
--- a/DashboardDialog.html
+++ b/DashboardDialog.html
@@ -73,7 +73,6 @@
                 <button id="packaging-btn" class="action-button">▶️ Iniciar Proceso de Envasado</button>
                 <button id="acq-btn" class="action-button">📝 Generar Borrador de Adquisiciones</button>
                 <button id="notify-btn" class="action-button">📲 Notificar a Proveedores</button>
-                <button id="finance-btn" class="action-button" style="background-color: #ffc107; color: black;">💲 Gestionar Finanzas</button>
             </div>
         </div>
         <div id="status-log">Bienvenido.</div>
@@ -171,7 +170,6 @@
         google.script.run.withSuccessHandler(() => setLoadingState(false)).withFailureHandler(handleError).showAcquisitionEditor();
     });
     document.getElementById('notify-btn').addEventListener('click', () => google.script.run.startNotificationProcess());
-    document.getElementById('finance-btn').addEventListener('click', () => google.script.run.showFinanceDashboard());
 
     function handleSuccess(message) {
         setLoadingState(false, message);

--- a/code.gs
+++ b/code.gs
@@ -1166,11 +1166,11 @@ function getReconciliationData() {
 // --- LÓGICA DEL DASHBOARD ---
 
 function showDashboard() {
-  updateAcquisitionListAutomated(); // Actualiza la lista de adquisiciones automáticamente
-  const html = HtmlService.createHtmlOutputFromFile('LauncherDialog')
-    .setWidth(400)
-    .setHeight(250);
-  SpreadsheetApp.getUi().showModalDialog(html, 'Abrir Dashboard');
+  updateAcquisitionListAutomated();
+  const html = HtmlService.createHtmlOutputFromFile('DashboardDialog')
+    .setWidth(1200)
+    .setHeight(800);
+  SpreadsheetApp.getUi().showModalDialog(html, 'Dashboard de Operaciones');
 }
 
 // --- FUNCIONES DE LA APLICACIÓN WEB ---


### PR DESCRIPTION
- Modified the `showDashboard` function to open the Operations Dashboard in a modal dialog within the Google Sheet, instead of a new browser tab. This resolves the issue where the dashboard was failing to launch correctly.
- Removed the "Gestionar Finanzas" button and its associated event listener from the dashboard as requested by the user.