### PR TITLE
fix(dashboard): Prevent automatic update of acquisition list

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -1161,7 +1161,6 @@ function getReconciliationData() {
 // --- LÓGICA DEL DASHBOARD ---
 
 function showDashboard() {
-  updateAcquisitionListAutomated();
   const html = HtmlService.createHtmlOutputFromFile('DashboardDialog')
     .setWidth(1200)
     .setHeight(800);


### PR DESCRIPTION
Removes the call to `updateAcquisitionListAutomated()` from the `showDashboard()` function.

This prevents the "Lista de Adquisiciones" sheet from being automatically updated every time the "Dashboard de Operaciones" is opened, as requested by the user. The update should only be triggered manually from the "Editar Borrador de Adquisiciones" dialog.