### PR TITLE
feat: Add order management features to dashboard

### DIFF
--- a/AppendOrdersDialog.html
+++ b/AppendOrdersDialog.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <base target="_top">
+  <meta charset="utf-8" />
+  <title>Agregar Pedidos por Lote</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 0; padding: 20px; background-color: #f8f9fa; }
+    .container { max-width: 600px; margin: auto; background: #fff; padding: 20px; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
+    h2 { text-align: center; color: #333; }
+    p { font-size: 14px; color: #555; line-height: 1.5; }
+    textarea {
+      width: 100%;
+      height: 250px;
+      padding: 10px;
+      border: 1px solid #ccc;
+      border-radius: 4px;
+      box-sizing: border-box;
+      font-size: 14px;
+      margin-top: 10px;
+    }
+    .buttons { display: flex; justify-content: flex-end; gap: 10px; margin-top: 20px; }
+    button {
+      padding: 10px 20px;
+      border: none;
+      border-radius: 4px;
+      cursor: pointer;
+      font-size: 14px;
+      font-weight: bold;
+    }
+    #import-btn { background-color: #007bff; color: white; }
+    #cancel-btn { background-color: #6c757d; color: white; }
+    #status { margin-top: 15px; text-align: center; color: #dc3545; font-weight: bold; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h2>Agregar Nuevos Pedidos</h2>
+    <p>Pega aquí los datos de los pedidos desde tu hoja de cálculo (incluyendo la fila de encabezados). Los datos deben estar separados por tabulaciones.</p>
+    <textarea id="paste-area" placeholder="Pega los datos aquí..."></textarea>
+    <div class="buttons">
+      <button type="button" id="cancel-btn">Cancelar</button>
+      <button type="button" id="import-btn">Agregar Pedidos</button>
+    </div>
+    <div id="status"></div>
+  </div>
+
+  <script>
+    document.getElementById('import-btn').addEventListener('click', function() {
+      const textData = document.getElementById('paste-area').value;
+      if (!textData.trim()) {
+        document.getElementById('status').textContent = 'El área de texto está vacía.';
+        return;
+      }
+
+      document.getElementById('import-btn').disabled = true;
+      document.getElementById('status').textContent = 'Agregando pedidos...';
+
+      google.script.run
+        .withSuccessHandler(function(response) {
+          if (response.status === 'success') {
+            alert(response.message);
+            google.script.host.close();
+          } else {
+            document.getElementById('status').textContent = 'Error: ' + response.message;
+            document.getElementById('import-btn').disabled = false;
+          }
+        })
+        .withFailureHandler(function(error) {
+          document.getElementById('status').textContent = 'Error: ' + error.message;
+          document.getElementById('import-btn').disabled = false;
+        })
+        .appendOrdersFromPastedText(textData);
+    });
+
+    document.getElementById('cancel-btn').addEventListener('click', function() {
+      google.script.host.close();
+    });
+  </script>
+</body>
+</html>

--- a/DashboardDialog.html
+++ b/DashboardDialog.html
@@ -105,6 +105,12 @@
             <button id="notify-btn" class="action-button">📲 Notificar a Proveedores</button>
             <button id="comanda-rutas-btn" class="action-button">🚚 Comanda Rutas</button>
         </div>
+        <div>
+            <p><strong>Gestión de Pedidos:</strong></p>
+            <button id="add-order-btn" class="action-button" style="background-color: #17a2b8;">➕ Agregar Pedido</button>
+            <button id="delete-order-btn" class="action-button" style="background-color: #dc3545;">➖ Eliminar Pedido</button>
+            <button id="view-deleted-btn" class="action-button" style="background-color: #6c757d;">👀 Ver Eliminados</button>
+        </div>
     </div>
     <div id="status-log">Bienvenido.</div>
   </div>
@@ -230,6 +236,32 @@
     });
     document.getElementById('notify-btn').addEventListener('click', () => google.script.run.openNotificationPanel());
     document.getElementById('comanda-rutas-btn').addEventListener('click', () => google.script.run.showComandaRutasDialog());
+
+    // --- LÓGICA PARA BOTONES DE GESTIÓN DE PEDIDOS ---
+    document.getElementById('add-order-btn').addEventListener('click', () => {
+        google.script.run.showAppendOrdersDialog();
+    });
+
+    document.getElementById('delete-order-btn').addEventListener('click', () => {
+        const orderId = prompt('Por favor, ingrese el Número de Pedido a eliminar:');
+        if (orderId && orderId.trim() !== '') {
+            setLoadingState(true, `Marcando pedido #${orderId} como eliminado...`);
+            google.script.run
+                .withSuccessHandler((response) => {
+                    if(response.status === 'success') {
+                        handleSuccess(response.message);
+                    } else {
+                        handleError({ message: response.message });
+                    }
+                })
+                .withFailureHandler(handleError)
+                .deleteOrder(orderId.trim());
+        }
+    });
+
+    document.getElementById('view-deleted-btn').addEventListener('click', () => {
+        google.script.run.showDeletedOrders();
+    });
   </script>
 </body>
 </html>


### PR DESCRIPTION
This commit introduces new functionality to the Operations Dashboard for managing orders in the 'Orders' sheet.

The following features have been added:
1.  **Add Orders (Paste)**: A new 'Agregar Pedido' button on the dashboard opens a dialog that allows the user to paste a block of tab-separated order data. These orders are then appended to the 'Orders' sheet. This replaces the previous form-based implementation based on user feedback.
2.  **Delete Order**: The 'Eliminar Pedido' button marks orders as 'deleted' instead of removing them. It prompts for an order number, finds all associated rows, colors them red, and prepends an 'E' to the quantity.
3.  **View Deleted Orders**: A 'Ver Eliminados' button generates and displays a report of all orders that have been marked as deleted, grouped by order number.