### PR TITLE
fix: Correctly populate quantity in packaging sheet

### DIFF
--- a/CategoryPanel.html
+++ b/CategoryPanel.html
@@ -103,7 +103,7 @@
 
 <script>
 /* ---------- Estado ---------- */
-let DATA = {};            // { "Fruta": {count, products:{ "Manzana": 12, ... }} , ...}
+let DATA = {};            // { "Fruta": {count, products:{ "Manzana": { total: 12, stock: "5 Kilo" }, ... }} , ...}
 let SELECTED = new Set(); // Categorías marcadas
 let ALL_CATEGORIES = [];  // Para el selector de edición
 let CURRENT_EDIT = { name: null, cat: null };
@@ -144,21 +144,26 @@ function render(data){
       <div class="body">
         <table>
           <thead><tr>
-            <th style="width:45%;">Producto</th>
-            <th style="width:15%;">Cant.</th>
-            <th style="width:25%;">Categoría</th>
+            <th style="width:40%;">Producto</th>
+            <th style="width:15%;">Cant. Pedida</th>
+            <th style="width:15%;">Stock Real</th>
+            <th style="width:15%;">Categoría</th>
             <th style="width:15%; text-align:right;">Acciones</th>
           </tr></thead>
           <tbody>
-          ${byKey(info.products).map(name => `
+          ${byKey(info.products).map(name => {
+            const productData = info.products[name];
+            return `
             <tr data-name="${esc(name)}" data-cat="${esc(cat)}">
               <td>${esc(name)}</td>
-              <td>${info.products[name]}</td>
+              <td>${productData.total}</td>
+              <td>${esc(productData.stock)}</td>
               <td><span class="tag">${esc(cat)}</span></td>
               <td class="row-actions">
                 <button class="btn ghost btn-edit">✏️ Editar</button>
               </td>
-            </tr>`).join('')}
+            </tr>`
+          }).join('')}
           </tbody>
         </table>
       </div>

--- a/code.gs
+++ b/code.gs
@@ -1471,25 +1471,80 @@ function getPackagingData() {
       productTotals[name] += parseInt(qty, 10) || 0;
     }
   });
+
+  const stockMap = getStockFromOrders();
   const categorySummary = {};
+
   for (const productName in productTotals) {
     const category = skuMap[productName] ? skuMap[productName].category : 'Sin Categoría';
-    if (!categorySummary[category]) { categorySummary[category] = { count: 0, products: {} }; }
+    if (!categorySummary[category]) {
+      categorySummary[category] = { count: 0, products: {} };
+    }
     categorySummary[category].count++;
-    categorySummary[category].products[productName] = productTotals[productName];
+
+    const inventoryInfo = stockMap[productName];
+    let inventoryValue = 'No encontrado';
+    if (inventoryInfo) {
+      const stock = String(inventoryInfo.quantity);
+      const unit = String(inventoryInfo.unit);
+      if (stock || unit) {
+        inventoryValue = `${stock} ${unit}`.trim();
+      }
+    }
+
+    categorySummary[category].products[productName] = {
+      total: productTotals[productName],
+      stock: inventoryValue
+    };
   }
   return categorySummary;
+}
+
+/**
+ * Crea un mapa de stock desde la hoja "Orders".
+ * @returns {Object<string, {quantity: any, unit: any}>} Un mapa donde las claves son
+ *   nombres de productos y los valores son objetos con stock y unidad.
+ */
+function getStockFromOrders() {
+  const ss = SpreadsheetApp.getActiveSpreadsheet();
+  const ordersSheet = ss.getSheetByName('Orders');
+  if (!ordersSheet) {
+    Logger.log("Error: La hoja 'Orders' no fue encontrada.");
+    return {};
+  }
+  const stockMap = {};
+  const lastRow = ordersSheet.getLastRow();
+  if (lastRow < 2) {
+    return stockMap;
+  }
+
+  // Columnas: J (Nombre Producto, index 10), AA (Stock Real, index 27), AB (Unidad Venta, index 28)
+  const data = ordersSheet.getRange(2, 10, lastRow - 1, 19).getValues(); // Lee desde la columna J hasta la AB
+
+  data.forEach(row => {
+    const productName = row[0];  // Columna J (índice 0 en el rango J:AB)
+    const stockReal = row[17]; // Columna AA (índice 17 en el rango J:AB)
+    const unit = row[18];      // Columna AB (índice 18 en el rango J:AB)
+
+    // Solo agregar si el producto existe y no ha sido mapeado aún.
+    // Esto asume que el stock es el mismo para todas las entradas del mismo producto.
+    if (productName && stockMap[productName] === undefined) {
+      stockMap[productName] = {
+        quantity: stockReal,
+        unit: unit
+      };
+    }
+  });
+
+  return stockMap;
 }
 
 function generatePackagingSheet(selectedCategories) {
   const ss = SpreadsheetApp.getActiveSpreadsheet();
   const data = getPackagingData();
 
-  // Obtener los mapas de datos necesarios para el inventario
-  const inventoryMap = getCurrentInventory();
-  const skuSheet = ss.getSheetByName('SKU');
-  if (!skuSheet) throw new Error("La hoja 'SKU' no fue encontrada.");
-  const skuMap = getSkuMap(skuSheet);
+  // Obtener el mapa de stock directamente desde la hoja "Orders".
+  const stockMap = getStockFromOrders();
 
   // Crear una hoja con un nombre único basado en la fecha
   const date = new Date();
@@ -1528,13 +1583,20 @@ function generatePackagingSheet(selectedCategories) {
 
     const productRows = [];
     sortedProductNames.forEach(productName => {
-      const skuInfo = skuMap[productName];
-      const baseProduct = skuInfo ? skuInfo.base : null;
-      const inventoryInfo = baseProduct ? inventoryMap[baseProduct] : null;
-      // Formatear el valor del inventario para incluir la unidad
-      const inventoryValue = inventoryInfo ? `${inventoryInfo.quantity} ${inventoryInfo.unit}` : 'No encontrado';
+      const inventoryInfo = stockMap[productName];
 
-      productRows.push([products[productName], inventoryValue, productName]);
+      // Formatear el valor del inventario para incluir la unidad
+      let inventoryValue = 'No encontrado';
+      if (inventoryInfo) {
+        const stock = String(inventoryInfo.quantity);
+        const unit = String(inventoryInfo.unit);
+        // Mostrar valor solo si hay cantidad o unidad.
+        if (stock || unit) {
+          inventoryValue = `${stock} ${unit}`.trim();
+        }
+      }
+
+      productRows.push([products[productName].total, inventoryValue, productName]);
     });
 
     if (productRows.length > 0) {


### PR DESCRIPTION
This commit fixes a bug where the 'Cantidad' column in the generated 'Lista de Envasado' sheet was being populated with a data object instead of the total sum of the product's quantity.

The `generatePackagingSheet` function in `code.gs` has been corrected to access the `.total` property of the product data object, ensuring the correct numerical value is used.