### PR TITLE
feat: Improve Comanda Rutas feature

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -580,14 +580,18 @@ function generatePrintableRouteSheets(vanName) {
     packagingSheet = ss.insertSheet(packagingSheetName);
   }
 
+  // Añadir título principal a la hoja de envasado
+  packagingSheet.getRange("A1").setValue(vanName).setFontSize(18).setFontWeight('bold').setHorizontalAlignment('center');
+  packagingSheet.getRange("A1:D1").merge();
+
   const packagingHeaders = ["Orden Ruta", "Nº Pedido", "Numero de Bultos", "Nombre Envasador"];
-  packagingSheet.getRange("A1:D1").setValues([packagingHeaders]).setFontWeight('bold');
+  packagingSheet.getRange("A2:D2").setValues([packagingHeaders]).setFontWeight('bold');
 
   if (finalPackagingData.length > 0) {
-    packagingSheet.getRange(2, 1, finalPackagingData.length, 4).setValues(finalPackagingData);
+    packagingSheet.getRange(3, 1, finalPackagingData.length, 4).setValues(finalPackagingData);
 
-    // Aplicar formato a la tabla
-    const tableRange = packagingSheet.getRange(1, 1, finalPackagingData.length + 1, 4);
+    // Aplicar formato a la tabla (incluyendo encabezados)
+    const tableRange = packagingSheet.getRange(2, 1, finalPackagingData.length + 1, 4);
     tableRange.setHorizontalAlignment("center")
               .setVerticalAlignment("middle")
               .setWrapStrategy(SpreadsheetApp.WrapStrategy.WRAP);


### PR DESCRIPTION
This commit introduces several improvements to the "Comanda Rutas" feature based on user feedback.

1.  **Persistent Van Assignments**: A "Furgon" column is now added to the "Orders" sheet to maintain a historical record of van assignments. The setup script ensures this column is present for both new and existing spreadsheets. The application logic already references this column by name, making the implementation robust.

2.  **Van Renaming**: "Furgon 1" and "Furgon 2" have been renamed to "Ignacio 1" and "Jeber 1" respectively in the dialog, as requested.

3.  **Packaging Sheet Title**: The printable "Orden de Envasado" (Packaging Order) sheet now includes a title with the van's name, making it consistent with the "Orden de Carga" (Loading Order) sheet for better clarity.