### PR TITLE
Fix footer overlapping content in Acquisition Editor

### DIFF
--- a/AcquisitionEditorDialog.html
+++ b/AcquisitionEditorDialog.html
@@ -4,9 +4,9 @@
   <base target="_top">
   <style>
     body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; margin: 0; background-color: #f0f2f5; color: #333; }
-    .container { padding: 20px; padding-bottom: 80px; }
+    .container { padding: 20px; /* padding-bottom will be set dynamically */ }
     h1 { color: #1c1e21; margin-top: 0; }
-    .filters { margin-top: 15px; margin-bottom: 15px; display: flex; gap: 20px; }
+    .filters { margin-top: 15px; margin-bottom: 15px; display: flex; gap: 20px; flex-wrap: wrap; }
     .filters label { font-weight: bold; display: flex; align-items: center; gap: 5px; }
     table { width: 100%; border-collapse: collapse; margin-top: 15px; }
     th, td { padding: 12px 8px; text-align: left; border-bottom: 1px solid #ddd; }
@@ -41,23 +41,29 @@
       padding: 15px 20px;
       background-color: #fff;
       border-top: 1px solid #ddd;
-      text-align: right;
       box-sizing: border-box;
+      /* Use flexbox for better alignment and wrapping */
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: flex-end;
+      align-items: center;
+      gap: 10px;
     }
     .button {
-      padding: 10px 20px;
+      padding: 10px 15px; /* Adjusted padding for better fit */
       font-size: 14px;
       font-weight: bold;
       border-radius: 5px;
       border: none;
       cursor: pointer;
       transition: background-color 0.2s;
+      white-space: nowrap; /* Prevent buttons from breaking line */
     }
     #save-btn { background-color: #1877f2; color: white; }
     #save-btn:disabled { background-color: #dcdfe3; color: #bec3c9; cursor: not-allowed; }
-    #cancel-btn { background-color: #e4e6eb; color: #4b4f56; margin-left: 10px; }
-    #just-in-time-btn, #wholesale-btn { background-color: #f0f2f5; color: #050505; border: 1px solid #bec3c9; margin-right: 10px; }
-    #status { margin-right: 15px; color: #606770; }
+    #cancel-btn { background-color: #e4e6eb; color: #4b4f56; }
+    #just-in-time-btn, #wholesale-btn, #show-all-btn { background-color: #f0f2f5; color: #050505; border: 1px solid #bec3c9; }
+    #status { margin-right: auto; /* Pushes status to the left */ color: #606770; }
   </style>
 </head>
 <body>
@@ -177,6 +183,19 @@
             updateRowAppearance(row, planData[index]);
           }
         });
+
+        // --- DYNAMIC PADDING ADJUSTMENT ---
+        const container = document.querySelector('.container');
+        const footer = document.querySelector('.footer-actions');
+        function adjustContainerPadding() {
+          if (footer) {
+            const footerHeight = footer.offsetHeight;
+            container.style.paddingBottom = (footerHeight + 20) + 'px';
+          }
+        }
+        adjustContainerPadding();
+        window.addEventListener('resize', adjustContainerPadding);
+        // --- END DYNAMIC PADDING ---
 
       } catch (e) {
         console.error("Error al procesar los datos iniciales:", e);


### PR DESCRIPTION
The fixed footer in the "Editar Borrador de Adquisiciones" dialog could overlap the last rows of the product list, especially on smaller screens where the buttons would wrap.

This change addresses the issue by:
- Using JavaScript to dynamically calculate the footer's height and set the main container's bottom padding accordingly. This ensures there is always enough space for the content, regardless of the footer's height.
- Updating the footer's CSS to use flexbox for better button alignment and wrapping.
- Removing the static bottom padding that was causing the issue.