### PR TITLE
feat: Add button to clear acquisitions list

### DIFF
--- a/AcquisitionEditorDialog.html
+++ b/AcquisitionEditorDialog.html
@@ -108,6 +108,7 @@
       <button id="wholesale-btn" class="button">Calcular Compra Mayorista</button>
       <button id="just-in-time-btn" class="button">Calcular Compra Justa</button>
       <button id="show-all-btn" class="button">Mostrar productos sin necesidad de compra</button>
+      <button id="clear-list-btn" class="button" style="background-color: #dc3545; color: white;">Limpiar Lista de Adquisiciones</button>
       <button id="save-btn" class="button" disabled>Guardar y Notificar</button>
       <button id="cancel-btn" class="button" onclick="google.script.host.close()">Cancelar</button>
   </div>
@@ -121,6 +122,7 @@
     const justInTimeBtn = document.getElementById('just-in-time-btn');
     const wholesaleBtn = document.getElementById('wholesale-btn');
     const showAllBtn = document.getElementById('show-all-btn');
+    const clearListBtn = document.getElementById('clear-list-btn');
     const statusSpan = document.getElementById('status');
     const categorySelect = document.getElementById('category-filter');
     const supplierFilter = document.getElementById('supplier-filter');
@@ -346,8 +348,27 @@
       justInTimeBtn.disabled = isLoading;
       wholesaleBtn.disabled = isLoading;
       showAllBtn.disabled = isLoading;
+      if(clearListBtn) clearListBtn.disabled = isLoading;
       statusSpan.textContent = message;
     }
+
+    clearListBtn.addEventListener('click', function() {
+      if (confirm('¿Estás seguro de que quieres limpiar TODA la lista de adquisiciones? Esta acción no se puede deshacer.')) {
+        setLoadingState(true, 'Limpiando lista...');
+        google.script.run
+          .withSuccessHandler(function(response) {
+            if (response.status === 'success') {
+              planData = [];
+              renderTable();
+              statusSpan.textContent = 'Lista limpiada. Puede recalcular o cerrar.';
+            }
+            setLoadingState(false, response.message);
+            alert(response.message);
+          })
+          .withFailureHandler(handleError)
+          .clearAcquisitionList();
+      }
+    });
 
     function handleDataSuccess(newData) {
       planData = processPlanData(newData.acquisitionPlan);

--- a/code.gs
+++ b/code.gs
@@ -1854,6 +1854,33 @@ function saveAcquisitions(finalPlan) {
   return { status: "success", message: "Lista de adquisiciones guardada con éxito." };
 }
 
+function clearAcquisitionList() {
+  try {
+    const ss = SpreadsheetApp.getActiveSpreadsheet();
+    let sheet = ss.getSheetByName("Lista de Adquisiciones");
+    if (sheet) {
+      sheet.clear();
+      sheet.clearConditionalFormatRules();
+    } else {
+      sheet = ss.insertSheet("Lista de Adquisiciones");
+    }
+
+    const headers = ["Producto Base", "Cantidad a Comprar", "Formato de Compra", "Inventario Actual", "Unidad Inventario Actual", "Necesidad de Venta", "Unidad Venta", "Inventario al Finalizar", "Unidad Inventario Final", "Precio Adq. Anterior", "Precio Adq. HOY", "Proveedor"];
+    sheet.getRange("A1:L1").setValues([headers]).setFontWeight("bold");
+    sheet.getRange("A1:C1").setBackground("#d9ead3");
+    sheet.getRange("D1:E1").setBackground("#fff2cc");
+    sheet.getRange("F1:K1").setBackground("#f4cccc");
+    sheet.getRange("L1").setBackground("#d9d9d9");
+    sheet.setFrozenRows(1);
+
+    SpreadsheetApp.flush(); // Ensure changes are saved
+    return { status: 'success', message: 'La lista de adquisiciones ha sido limpiada con éxito.' };
+  } catch (e) {
+    Logger.log(`Error en clearAcquisitionList: ${e.stack}`);
+    return { status: 'error', message: `Ocurrió un error al limpiar la lista: ${e.message}` };
+  }
+}
+
 function generateAcquisitionDRAFT() {
   const ss = SpreadsheetApp.getActiveSpreadsheet();
   const ordersSheet = ss.getSheetByName('Orders');


### PR DESCRIPTION
This commit introduces a new button, 'Limpiar Lista de Adquisiciones', in the 'Editar Borrador de Adquisiciones' panel.

- A new function `clearAcquisitionList` has been added to `code.gs`. This function clears all data from the 'Lista de Adquisiciones' sheet while preserving the header row and its formatting.
- The 'Limpiar Lista de Adquisiciones' button has been added to `AcquisitionEditorDialog.html`.
- Client-side JavaScript has been implemented to handle the button's click event. It includes a confirmation dialog to prevent accidental data deletion and calls the new server-side function.
- The UI is updated to reflect the cleared list and provides feedback to the user.