### PR TITLE
Fix column name error in order processing script

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -480,7 +480,8 @@ function indexer(headers) {
     comuna:    idxOf('comuna','shipping region','ciudad'),
     estado:    idxOf('estado','estado del pago'),
     furgon:    idxOf('furgón','furgon','van','furgón asignado'),
-    cantidad:  idxOf('item quantity', 'cantidad')
+    cantidad:  idxOf('item quantity', 'cantidad'),
+    producto:  idxOf('item name', 'nombre producto', 'producto')
   };
 }
 
@@ -1797,9 +1798,11 @@ function getPackagingDataForExtraTime(statusToProcess) {
   const allOrderData = ordersSheet.getRange(2, 1, lastRow - 1, ordersSheet.getLastColumn()).getValues();
 
   const headers = ordersSheet.getRange(1, 1, 1, ordersSheet.getLastColumn()).getValues()[0];
-  const nameColIdx = headers.indexOf("Item Name");
-  const qtyColIdx = headers.indexOf("Item Quantity");
-  const statusColIdx = headers.indexOf("Estado");
+  const idx = indexer(headers);
+  const nameColIdx = idx.producto;
+  const qtyColIdx = idx.cantidad;
+  const statusColIdx = idx.estado;
+
 
   if (nameColIdx === -1 || qtyColIdx === -1 || statusColIdx === -1) {
     throw new Error("Faltan columnas requeridas: 'Item Name', 'Item Quantity' o 'Estado'.");


### PR DESCRIPTION
The "Procesar Pedidos Agregados" feature was failing with a "Missing required columns" error because the script was looking for hardcoded column names ('Item Name', 'Item Quantity') in the 'Orders' sheet.

This change resolves the issue by:
1.  Updating the `indexer` utility function to include Spanish aliases ('Nombre Producto', 'producto') for the product name column.
2.  Refactoring the `getPackagingDataForExtraTime` function to use the flexible `indexer` function instead of `indexOf` to find the required column indices.

This makes the script more robust and resilient to variations in the input sheet's column headers.