### PR TITLE
feat: Improve logic for processing added orders

### DIFF
--- a/DashboardDialog.html
+++ b/DashboardDialog.html
@@ -397,19 +397,16 @@
     document.getElementById('process-extra-orders-btn').addEventListener('click', () => {
         setLoadingState(true, 'Buscando y procesando pedidos agregados...');
         google.script.run
-            .withSuccessHandler(url => {
-                setLoadingState(false);
-                if (url) {
-                    // Abrir la URL del PDF en una nueva pestaña
-                    window.open(url, '_blank');
-                    setLoadingState(false, '¡Lista de envasado generada y abierta en una nueva pestaña!');
-                } else {
-                    // Si no hay URL, es porque no había nada que procesar o hubo un error manejado con alerta.
-                    setLoadingState(false);
+            .withSuccessHandler(response => {
+                setLoadingState(false, (response && response.message) || 'Proceso completado.');
+                if (response && response.message) {
+                    alert(response.message);
+                }
+                if (response && response.url) {
+                    window.open(response.url, '_blank');
                 }
             })
             .withFailureHandler(err => {
-                // Re-habilita los botones y muestra el error.
                 handleError(err);
             })
             .processExtraTimeOrders();


### PR DESCRIPTION
This commit refactors the logic behind the 'Procesar Pedidos Agregados' button.

The new implementation introduces a more sophisticated inventory and acquisition calculation for orders added in a second stage (e.g., 'Aprobado y Agregado en 2do Tiempo').

Key changes:
- The 'Inventario al Finalizar' from the main acquisitions list is now used as the starting inventory for newly added orders.
- The system calculates if there is a shortfall between the needs of the new orders and this available inventory.
- If a shortfall exists, new acquisition lines are automatically calculated and appended to the 'Lista de Adquisiciones' sheet.
- These new acquisition lines are tagged in a new 'Etiqueta' column (M) for easy identification (e.g., 'Adicion 2do Tiempo').
- The generated 'Lista de Envasado' now correctly displays the 'Inventario al Finalizar' from the previous run as the 'Inventario Actual' for these items.
- The user feedback mechanism has been improved to provide a clear summary of the actions taken.