### PR TITLE
feat: Add packaging list viewer and update extraction logic

### DIFF
--- a/DashboardDialog.html
+++ b/DashboardDialog.html
@@ -202,6 +202,7 @@
             <p><strong>Acciones de Operación:</strong></p>
             <button id="packaging-btn" class="action-button">▶️ Iniciar Proceso de Envasado</button>
             <button id="extract-order-btn" class="action-button" style="background-color: #fd7e14;">⚡ Extraer Pedido Urgente</button>
+            <button id="view-envasado-btn" class="action-button" style="background-color: #20c997;">👁️ Ver Listas Envasado</button>
             <button id="acq-btn" class="action-button">📝 Generar Adquisiciones</button>
             <button id="notify-btn" class="action-button">📲 Notificar a Proveedores</button>
             <button id="comanda-rutas-btn" class="action-button">🚚 Comanda Rutas</button>
@@ -390,6 +391,10 @@
         .withSuccessHandler(() => setLoadingState(false)) // Simply reset loading state on success
         .withFailureHandler(handleError)
         .showExtractionDialog();
+    });
+
+    document.getElementById('view-envasado-btn').addEventListener('click', () => {
+      google.script.run.showEnvasadoViewerDialog();
     });
 
     document.getElementById('acq-btn').addEventListener('click', () => {

--- a/EnvasadoViewerDialog.html
+++ b/EnvasadoViewerDialog.html
@@ -1,0 +1,166 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <base target="_top">
+    <style>
+      body { font-family: Roboto, Arial, sans-serif; margin: 0; background-color: #f8f9fa; }
+      .container { padding: 20px; }
+      h2 { margin-top: 0; border-bottom: 1px solid #dee2e6; padding-bottom: 10px; color: #495057; }
+      #sheet-list { list-style-type: none; padding: 0; margin: 0; border: 1px solid #dee2e6; border-radius: 8px; background-color: #fff; overflow: hidden; }
+      .sheet-item {
+        /* display: flex; */
+        /* justify-content: space-between; */
+        /* align-items: center; */
+        padding: 12px 15px;
+        border-bottom: 1px solid #eee;
+        cursor: pointer;
+        transition: background-color 0.2s;
+      }
+      .sheet-item:last-child { border-bottom: none; }
+      .sheet-item:hover { background-color: #f1f3f5; }
+      .sheet-item.active { background-color: #e9ecef; }
+      .sheet-main-content { font-weight: 500; color: #212529; }
+      .actions { display: none; padding-top: 10px; margin-top: 10px; border-top: 1px dashed #ced4da; }
+      .sheet-item.active .actions { display: flex; justify-content: flex-end; gap: 10px; }
+      .btn {
+        border: none;
+        color: white;
+        padding: 8px 16px;
+        text-align: center;
+        text-decoration: none;
+        display: inline-block;
+        font-size: 13px;
+        font-weight: 500;
+        cursor: pointer;
+        border-radius: 5px;
+        transition: opacity 0.2s;
+      }
+      .btn:hover { opacity: 0.9; }
+      .btn-pdf { background-color: #c82333; } /* Rojo oscuro */
+      .btn-print { background-color: #0069d9; } /* Azul oscuro */
+      .loader-container { text-align: center; padding: 40px; }
+      .loader {
+        border: 5px solid #f3f3f3;
+        border-radius: 50%;
+        border-top: 5px solid #3498db;
+        width: 30px;
+        height: 30px;
+        animation: spin 1.5s linear infinite;
+        display: inline-block;
+      }
+      .empty-state { text-align: center; color: #6c757d; margin-top: 20px; padding: 20px; background-color: #e9ecef; border-radius: 8px; }
+      @keyframes spin {
+        0% { transform: rotate(0deg); }
+        100% { transform: rotate(360deg); }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <h2>Listas de Envasado Creadas</h2>
+      <div id="list-container">
+        <div class="loader-container"><div class="loader"></div></div>
+      </div>
+    </div>
+
+    <script>
+      let spreadsheetId = null;
+
+      document.addEventListener('DOMContentLoaded', () => {
+        google.script.run
+          .withSuccessHandler(id => {
+            spreadsheetId = id;
+            loadSheets();
+          })
+          .withFailureHandler(handleError)
+          .getActiveSpreadsheetId();
+      });
+
+      function loadSheets() {
+        google.script.run
+          .withSuccessHandler(handleSuccess)
+          .withFailureHandler(handleError)
+          .getEnvasadoSheets();
+      }
+
+      function handleSuccess(response) {
+        const container = document.getElementById('list-container');
+        container.innerHTML = '';
+
+        if (response.ok && response.sheets && response.sheets.length > 0) {
+          const list = document.createElement('ul');
+          list.id = 'sheet-list';
+          response.sheets.forEach(sheet => {
+            const item = document.createElement('li');
+            item.className = 'sheet-item';
+
+            const mainContent = document.createElement('div');
+            mainContent.className = 'sheet-main-content';
+            mainContent.innerHTML = `<span class="sheet-name">${escapeHtml(sheet.name)}</span>`;
+
+            const actionsContainer = document.createElement('div');
+            actionsContainer.className = 'actions';
+            actionsContainer.innerHTML = `
+                <button class="btn btn-pdf">PDF</button>
+                <button class="btn btn-print">Imprimir</button>
+            `;
+
+            item.appendChild(mainContent);
+            item.appendChild(actionsContainer);
+
+            item.addEventListener('click', (e) => {
+              if (e.target.tagName === 'BUTTON') return;
+              const currentActive = document.querySelector('.sheet-item.active');
+              if (currentActive && currentActive !== item) {
+                currentActive.classList.remove('active');
+              }
+              item.classList.toggle('active');
+            });
+
+            actionsContainer.querySelector('.btn-pdf').addEventListener('click', e => {
+              e.stopPropagation();
+              openUrl(sheet.id, 'pdf');
+            });
+
+            actionsContainer.querySelector('.btn-print').addEventListener('click', e => {
+              e.stopPropagation();
+              openUrl(sheet.id, 'print');
+            });
+
+            list.appendChild(item);
+          });
+          container.appendChild(list);
+        } else {
+          let message = 'No se encontraron listas de envasado.';
+          if (response && !response.ok) {
+            message = `Error: ${response.error}`;
+          }
+          container.innerHTML = `<div class="empty-state">${message}</div>`;
+        }
+      }
+
+      function handleError(error) {
+        const container = document.getElementById('list-container');
+        container.innerHTML = `<div class="empty-state">Error al cargar: ${error.message}</div>`;
+      }
+
+      function openUrl(sheetId, type) {
+        if (!spreadsheetId) {
+          handleError({message: "El ID de la hoja de cálculo no está disponible."});
+          return;
+        }
+        const url = `https://docs.google.com/spreadsheets/d/${spreadsheetId}/export?format=pdf&gid=${sheetId}&portrait=true&fitw=true&gridlines=true&printtitle=false&sheetnames=false&pagenum=CENTER`;
+        window.open(url, '_blank');
+      }
+
+      function escapeHtml(unsafe) {
+        return unsafe
+             .replace(/&/g, "&amp;")
+             .replace(/</g, "&lt;")
+             .replace(/>/g, "&gt;")
+             .replace(/"/g, "&quot;")
+             .replace(/'/g, "&#039;");
+      }
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
This commit introduces two main changes to the packaging workflow:

1.  **Cumulative Post-Extraction Sheet:** The "Extraer Pedido Urgente" flow is updated. The `extractOrdersFromPackingList` function now uses `PropertiesService` to store a list of all orders extracted during a given day. This ensures that the "Lista de Envasado - Post Extraccion - fecha" sheet is always a cumulative reflection of all remaining items to be packed for that day, rather than just a reflection of the most recent extraction.

2.  **Packaging List Viewer:** A new "Ver Listas Envasado" button has been added to the main operations dashboard. This button opens a new dialog that lists all generated "Lista de Envasado" sheets. Users can click on a sheet in this viewer to get options to download it as a PDF or print it.

These changes address the user's request to streamline the packaging process by making the daily post-extraction list cumulative and providing an easy way to view and access all historical and current packaging lists.