### PR TITLE
feat: Add 'Limpiar Sesion Anterior' button to dashboard

### DIFF
--- a/DashboardDialog.html
+++ b/DashboardDialog.html
@@ -189,8 +189,11 @@
     <h2>Flujo de Trabajo Diario</h2>
     <div class="actions-grid">
         <div>
-            <p><strong>Paso 1:</strong> Carga los pedidos del día.</p>
-            <button id="paste-import-btn" class="action-button">Importar Pedidos (Copiar y Pegar)</button>
+            <p><strong>Paso 1:</strong> Carga los pedidos del día y/o limpia la sesión anterior.</p>
+            <div style="display: flex; gap: 10px; margin-bottom: 10px;">
+                <button id="paste-import-btn" class="action-button" style="margin-bottom: 0; flex: 1;">Importar Pedidos (Copiar y Pegar)</button>
+                <button id="clean-session-btn" class="action-button" style="margin-bottom: 0; flex: 1; background-color: #fd7e14;">Limpiar Sesion Anterior</button>
+            </div>
             <p><strong>Paso 2:</strong> Revisa y limpia los datos.</p>
             <button id="clean-btn" class="action-button">Limpiar Datos (Duplicados y Proveedores)</button>
             <p><strong>Paso 3:</strong> Importa los movimientos del banco.</p>
@@ -377,6 +380,15 @@
     }
 
     document.getElementById('paste-import-btn').addEventListener('click', () => google.script.run.showPasteImportDialog());
+
+    document.getElementById('clean-session-btn').addEventListener('click', () => {
+        const confirmed = confirm('¿Estás seguro de que quieres eliminar TODAS las hojas de "Lista de Envasado" y "Extraccion"? Esta acción no se puede deshacer.');
+        if (confirmed) {
+            setLoadingState(true, 'Limpiando hojas de la sesión anterior...');
+            google.script.run.withSuccessHandler(handleSuccess).withFailureHandler(handleError).cleanPreviousSession();
+        }
+    });
+
     document.getElementById('clean-btn').addEventListener('click', () => {
         setLoadingState(true, 'Iniciando limpieza de datos...');
         google.script.run.withSuccessHandler(() => setLoadingState(false)).withFailureHandler(handleError).startDashboardRefresh();

--- a/code.gs
+++ b/code.gs
@@ -693,6 +693,35 @@ function cleanupRouteSheets() {
   }
 }
 
+/**
+ * Elimina todas las hojas de "Lista de Envasado" y "Extraccion" de sesiones anteriores.
+ */
+function cleanPreviousSession() {
+  try {
+    const ss = SpreadsheetApp.getActiveSpreadsheet();
+    const allSheets = ss.getSheets();
+    let deletedCount = 0;
+
+    allSheets.forEach(sheet => {
+      const sheetName = sheet.getName();
+      if (sheetName.startsWith('Lista de Envasado') || sheetName.startsWith('Extraccion')) {
+        ss.deleteSheet(sheet);
+        deletedCount++;
+      }
+    });
+
+    if (deletedCount > 0) {
+      return `Limpieza completada. Se eliminaron ${deletedCount} hoja(s) de la sesión anterior.`;
+    } else {
+      return 'No se encontraron hojas de "Lista de Envasado" o "Extraccion" para eliminar.';
+    }
+  } catch (e) {
+    Logger.log(`Error en cleanPreviousSession: ${e.stack}`);
+    // Re-throw the error to be caught by withFailureHandler on the client-side
+    throw new Error(`Ocurrió un error al limpiar las hojas: ${e.message}`);
+  }
+}
+
 
 // --- MÓDULO DE FINANZAS ---
 


### PR DESCRIPTION
This commit introduces a new "Limpiar Sesion Anterior" button to the main operations dashboard.

- The new button is added to `DashboardDialog.html` and placed next to the "Importar Pedidos" button, visually grouped as requested.
- A new function, `cleanPreviousSession`, has been added to `code.gs`. This function deletes all sheets in the spreadsheet whose names start with "Lista de Envasado" or "Extraccion".
- A confirmation dialog is shown to the user before the deletion is performed to prevent accidental data loss.