### PR TITLE
Fix Acquisition Editor UI and 'Just-in-Time' logic

### DIFF
--- a/AcquisitionEditorDialog.html
+++ b/AcquisitionEditorDialog.html
@@ -113,11 +113,7 @@
       <button id="wholesale-btn" class="button">Calcular Compra Mayorista</button>
       <button id="just-in-time-btn" class="button">Calcular Compra Justa</button>
       <button id="show-all-btn" class="button">Mostrar productos sin necesidad de compra</button>
- feature/conditional-acquisition-quantity
-      <button id="clear-list-btn" class="button">Limpiar Lista de Adquisiciones</button>
-
       <button id="clear-list-btn" class="button" style="background-color: #dc3545; color: white;">Limpiar Lista de Adquisiciones</button>
- main
       <button id="save-btn" class="button" disabled>Guardar y Notificar</button>
       <button id="cancel-btn" class="button" onclick="google.script.host.close()">Cancelar</button>
   </div>
@@ -394,24 +390,6 @@
       if(clearListBtn) clearListBtn.disabled = isLoading;
       statusSpan.textContent = message;
     }
-
-    clearListBtn.addEventListener('click', function() {
-      if (confirm('¿Estás seguro de que quieres limpiar TODA la lista de adquisiciones? Esta acción no se puede deshacer.')) {
-        setLoadingState(true, 'Limpiando lista...');
-        google.script.run
-          .withSuccessHandler(function(response) {
-            if (response.status === 'success') {
-              planData = [];
-              renderTable();
-              statusSpan.textContent = 'Lista limpiada. Puede recalcular o cerrar.';
-            }
-            setLoadingState(false, response.message);
-            alert(response.message);
-          })
-          .withFailureHandler(handleError)
-          .clearAcquisitionList();
-      }
-    });
 
     function handleDataSuccess(newData) {
       planData = processPlanData(newData.acquisitionPlan);


### PR DESCRIPTION
This commit addresses two issues in the Acquisition Editor:

1. The "Calcular Compra Justa" (Just-in-Time) calculation was creating duplicate entries for the same base product with different purchase formats. The logic has been updated to generate only a single entry per product, using the smallest available purchase format to meet the required need.

2. The editor's footer UI was cluttered with a duplicate "Limpiar Lista de Adquisiciones" button and leftover text from a previous merge. The HTML and corresponding JavaScript have been cleaned up to fix the UI and remove redundant code.