### PR TITLE
feat(dashboard): extend session cleanup to delete more sheets

### DIFF
--- a/DashboardDialog.html
+++ b/DashboardDialog.html
@@ -384,7 +384,7 @@
     document.getElementById('paste-import-btn').addEventListener('click', () => google.script.run.showPasteImportDialog());
 
     document.getElementById('clean-session-btn').addEventListener('click', () => {
-        const confirmed = confirm('¿Estás seguro de que quieres eliminar TODAS las hojas de "Lista de Envasado" y "Extraccion"? Esta acción no se puede deshacer.');
+        const confirmed = confirm('¿Estás seguro de que quieres eliminar TODAS las hojas de "Lista de Envasado", "Extraccion", "Ruta", "Orden de Envasado" y "Orden de Carga"? Esta acción no se puede deshacer.');
         if (confirmed) {
             setLoadingState(true, 'Limpiando hojas de la sesión anterior...');
             google.script.run.withSuccessHandler(handleSuccess).withFailureHandler(handleError).cleanPreviousSession();

--- a/code.gs
+++ b/code.gs
@@ -672,29 +672,9 @@ function generatePrintableRouteSheets(vanName) {
   };
 }
 
-function cleanupRouteSheets() {
-  try {
-    const ss = SpreadsheetApp.getActiveSpreadsheet();
-    const allSheets = ss.getSheets();
-    let deletedCount = 0;
-
-    allSheets.forEach(sheet => {
-      const sheetName = sheet.getName();
-      if (sheetName.startsWith('Ruta Optimizada -') || sheetName.startsWith('Orden de Envasado -') || sheetName.startsWith('Orden de Carga -')) {
-        ss.deleteSheet(sheet);
-        deletedCount++;
-      }
-    });
-
-    return { status: 'success', message: `Limpieza completada. Se eliminaron ${deletedCount} hojas.` };
-  } catch (e) {
-    Logger.log(e);
-    return { status: 'error', message: e.toString() };
-  }
-}
 
 /**
- * Elimina todas las hojas de "Lista de Envasado" y "Extraccion" de sesiones anteriores.
+ * Elimina todas las hojas de "Lista de Envasado", "Extraccion", "Ruta" y "Orden de Envasado" de sesiones anteriores.
  */
 function cleanPreviousSession() {
   try {
@@ -704,7 +684,11 @@ function cleanPreviousSession() {
 
     allSheets.forEach(sheet => {
       const sheetName = sheet.getName();
-      if (sheetName.startsWith('Lista de Envasado') || sheetName.startsWith('Extraccion')) {
+      if (sheetName.startsWith('Lista de Envasado') ||
+          sheetName.startsWith('Extraccion') ||
+          sheetName.startsWith('Ruta') ||
+          sheetName.startsWith('Orden de Envasado') ||
+          sheetName.startsWith('Orden de Carga')) {
         ss.deleteSheet(sheet);
         deletedCount++;
       }
@@ -713,7 +697,7 @@ function cleanPreviousSession() {
     if (deletedCount > 0) {
       return `Limpieza completada. Se eliminaron ${deletedCount} hoja(s) de la sesión anterior.`;
     } else {
-      return 'No se encontraron hojas de "Lista de Envasado" o "Extraccion" para eliminar.';
+      return 'No se encontraron hojas de sesiones anteriores para eliminar.';
     }
   } catch (e) {
     Logger.log(`Error en cleanPreviousSession: ${e.stack}`);


### PR DESCRIPTION
Updates the 'Limpiar Sesion Anterior' functionality to also delete sheets starting with 'Ruta', 'Orden de Envasado', and 'Orden de Carga'.

The `cleanPreviousSession` function in `code.gs` now includes the logic to remove these sheets. The confirmation message in `DashboardDialog.html` has been updated accordingly.

The now-redundant `cleanupRouteSheets` function has been removed.