### PR TITLE
Feature: Default to wholesale view in acquisitions editor

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -2895,7 +2895,7 @@ function calculateNewAcquisitionPlan(mode = 'wholesale') {
 }
 
 function showAcquisitionEditor() {
-  const dataForEditor = getAcquisitionDataForEditor();
+  const dataForEditor = getAcquisitionDataForEditor('wholesale');
   const template = HtmlService.createTemplateFromFile('AcquisitionEditorDialog');
   // Pasar el objeto de datos directamente al template. La serialización se hará en el lado del cliente.
   template.data = dataForEditor;


### PR DESCRIPTION
The `showAcquisitionEditor` function has been modified to always calculate the 'wholesale' purchase plan when the dialog is opened. This ensures that the acquisitions editor consistently defaults to the 'Compra Mayorista' view, as requested by the user.